### PR TITLE
replaces all versions of nodejs to 10.x 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ aws lambda create-function \
 --handler cloudwatch.putMetricDataSingleValue \
 --timeout 60 \
 --memory-size 1024 \
---runtime nodejs8.10
+--runtime nodejs10.x
 ```
 
 2. Create a Lambda function that will perform PutMetricData with values and counts.
@@ -53,7 +53,7 @@ aws lambda create-function \
 --handler cloudwatch.putMetricDataValuesAndCounts \
 --timeout 60 \
 --memory-size 1024 \
---runtime nodejs8.10
+--runtime nodejs10.x
 ```
 
 ### Create Kinesis stream


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #1 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
