### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ aws lambda create-function \
 --handler cloudwatch.putMetricDataSingleValue \
 --timeout 60 \
 --memory-size 1024 \
---runtime nodejs10.x
+--runtime nodejs14.x
 ```
 
 2. Create a Lambda function that will perform PutMetricData with values and counts.
@@ -53,7 +53,7 @@ aws lambda create-function \
 --handler cloudwatch.putMetricDataValuesAndCounts \
 --timeout 60 \
 --memory-size 1024 \
---runtime nodejs10.x
+--runtime nodejs14.x
 ```
 
 ### Create Kinesis stream


### PR DESCRIPTION
CloudFormation templates in amazon-cloudwatch-percentiles-high-volume-data-monitoring have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.